### PR TITLE
flutter 3.29にアップデートする際に、サポートされなくなったAndroidのAPIがあったので削除

### DIFF
--- a/.idea/libraries/Flutter_Plugins.xml
+++ b/.idea/libraries/Flutter_Plugins.xml
@@ -2,6 +2,15 @@
   <library name="Flutter Plugins" type="FlutterPluginsLibraryType">
     <CLASSES>
       <root url="file://$PROJECT_DIR$" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_web-2.2.1" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences-2.2.2" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_android-2.1.3" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/path_provider_linux-2.1.10" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/path_provider_windows-2.1.6" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_windows-2.3.2" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_linux-2.3.2" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_macos-2.0.5" />
+      <root url="file://$USER_HOME$/.pub-cache/hosted/pub.dev/shared_preferences_foundation-2.2.1" />
     </CLASSES>
     <JAVADOC />
     <SOURCES />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="FrameworkDetectionExcludesConfiguration">
     <type id="android" />

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.10 - 2024-06-09
+
+* Update packages
+
 ## 2.0.9 - 2023-10-14
 
 * Update packages

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To manage the migration use this package https://pub.dev/packages/version_migrat
 Add in pubspec:
 
 ```
-native_shared_preferences: ^2.0.9
+native_shared_preferences: ^2.0.10
 ```
 
 ## Usage

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:8.1.2'
     }
 }
 
@@ -22,7 +22,7 @@ rootProject.allprojects {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
     if (project.android.hasProperty("namespace")) {
         namespace 'yeniellandestoy.native_shared_preferences'

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip

--- a/android/src/main/java/yeniellandestoy/native_shared_preferences/NativeSharedPreferencesPlugin.java
+++ b/android/src/main/java/yeniellandestoy/native_shared_preferences/NativeSharedPreferencesPlugin.java
@@ -12,11 +12,6 @@ public class NativeSharedPreferencesPlugin implements FlutterPlugin {
   private static final String CHANNEL_NAME = "native_shared_preferences";
   private MethodChannel channel;
 
-  public static void registerWith(PluginRegistry.Registrar registrar) {
-    final NativeSharedPreferencesPlugin plugin = new NativeSharedPreferencesPlugin();
-    plugin.setupChannel(registrar.messenger(), registrar.context());
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPlugin.FlutterPluginBinding binding) {
     setupChannel(binding.getBinaryMessenger(), binding.getApplicationContext());

--- a/ios/Classes/NativeSharedPreferencesPlugin.m
+++ b/ios/Classes/NativeSharedPreferencesPlugin.m
@@ -95,6 +95,8 @@
                     
                     [self mapDateToMilliseconds:(NSDictionary *)element mappedDictionary:newMappedDictionary];
                     [newArray addObject:newMappedDictionary];
+                } else if ([element isKindOfClass:[NSDate class]]) { 
+                    [newArray addObject:[NSNumber numberWithDouble:floor([((NSDate *)element) timeIntervalSince1970] * 1000)]];
                 } else {
                     [newArray addObject:element];
                 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: native_shared_preferences
 description: This packages is a copy of the shared_prefrences package but without the prefix in the keys. Is used to migrate the data from previous native app.
-version: 2.0.9
+version: 2.0.10
 homepage: https://github.com/yeniel/native_shared_preferences
 
 environment:


### PR DESCRIPTION
https://github.com/yeniel/native_shared_preferences/pull/22

こちらと同様の変更を加えました。

この変更を加えないとAndroidのビルドに失敗します。